### PR TITLE
Showing CEPL window on Windows under SLIME

### DIFF
--- a/cepl.sdl2.lisp
+++ b/cepl.sdl2.lisp
@@ -21,6 +21,12 @@
                                           ,(when resizable :resizable)
                                           ,(when no-frame :borderless)
                                           ,(when hidden :hidden))))))
+    #+windows ; hack to fix CEPL hangup on Windows under SLIME
+    (progn
+      (sdl2:hide-window win)
+      (sdl2:show-window win)
+      (when hidden
+        (sdl2:hide-window win)))
     #+darwin
     (progn
       (setf cl-opengl-bindings::*gl-get-proc-address* #'sdl2::gl-get-proc-address)


### PR DESCRIPTION
This fix makes CEPL usable under Windows. There is no need in additional configuration on the Emacs/SLIME side (like running Lisp in single threaded mode). It seems like running graphics code in the main thread is not the real issue.

The actual bug is probably in the SDL2, see additional information in this discussion:
https://github.com/lispgames/cl-sdl2/issues/23

The solution I propose is somewhat hacky, but it works.
